### PR TITLE
@example tag examples will be shown with a header and formatted code samples

### DIFF
--- a/template/index.jade
+++ b/template/index.jade
@@ -121,7 +121,7 @@ html
             each tag in symbol.tags
               if tag.type == 'example' 
                 pre
-                  code.language-javascript !{tag.html}
+                  code.language-javascript !{tag.string}
     footer.footer
       div.container
         p Documentation generated with 

--- a/template/index.jade
+++ b/template/index.jade
@@ -114,7 +114,14 @@ html
               h5 JSFiddle
               p
                 iframe(width="100%", height="300", src=symbol.jsfiddle , allowfullscreen="allowfullscreen", frameborder="0")
-
+            each tag in symbol.tags
+              if tag.type == 'example' 
+                h3 Examples
+                -break;
+            each tag in symbol.tags
+              if tag.type == 'example' 
+                pre
+                  code.language-javascript !{tag.html}
     footer.footer
       div.container
         p Documentation generated with 


### PR DESCRIPTION
Original issue mr-doc/mr-doc#105

This supports multiple example tags as well.
I'm new to Jade so please let me know if there's a better way!
