### PR TITLE
Update Mr-Doc dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "gulp": "^3.9.0",
-    "mr-doc": "git+https://github.com/mr-doc/mr-doc.git"
+    "mr-doc": "^3.2.1"
   },
   "devDependencies": {
     "glob": "^5.0.14",


### PR DESCRIPTION
As per v4 updates documentation, "Themes that currently exist will not work with v4 and beyond. Even the theming system will not be available in v4." As such, we should limit the mr-doc dependency to the version of mr-doc that the theme will work with. We are currently running into an issue where this theme is trying to use the latest version and causes npm errors, especially if installing mr-doc from npm.